### PR TITLE
Update: Updated the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# package-files
+package-lock.json


### PR DESCRIPTION
As we know package-lock.json is automatically generated for any operations where npm modifies either the node_modules tree, or package.json. 

Every time when we run npm install, package-lock.json file updated and we have to commit the changes. If we don't commit it, then the version of the application everyone else will get is different than what we are running locally. 

So that, when we push the changes this file should not be considered, as ideally it should be in the .gitignore file 