### PR TITLE
Exporting the custom-tag-service.ts service.

### DIFF
--- a/projects/angular-formio/src/index.ts
+++ b/projects/angular-formio/src/index.ts
@@ -1,5 +1,6 @@
 export * from './core';
 export * from './elements.common';
+export * from './custom-component/custom-tags.service';
 export * from './custom-component/create-custom-component';
 export * from './custom-component/register-custom-component';
 export { default as FormioSubmission } from './types/formio-submission';


### PR DESCRIPTION
In some projects, we need to customize the Formio based on our needs, so, services like components should be exported in order to use in other places. As you know, this service can be injected into the `FormioComponent` component (projects/angular-formio/src/components/formio/formio.component.ts).
In this PR, this service is exported, so, we are able to use this service from the outer of this package.

Issue: #877