### PR TITLE
chore: fix builder change event emitter

### DIFF
--- a/projects/angular-formio/src/components/formbuilder/formbuilder.component.ts
+++ b/projects/angular-formio/src/components/formbuilder/formbuilder.component.ts
@@ -43,7 +43,7 @@ export class FormBuilderComponent implements OnInit, OnChanges, OnDestroy {
   @Input() noeval ? = false;
   @Input() refresh?: Observable<void>;
   @Input() rebuild?: Observable<object>;
-  @Output() change?: EventEmitter<object>;
+  @Output() change: EventEmitter<object>;
   @ViewChild('builder', { static: true }) builderElement?: ElementRef<any>;
 
   constructor(


### PR DESCRIPTION
Fixes issue `Object is possibly 'undefined'.`

Output event emitter should not be optional

Causes possibly undefined error, which prevents the change event from working in some environments


<img width="1073" alt="Screenshot 2023-04-13 at 10 17 09 AM" src="https://user-images.githubusercontent.com/13836016/231822205-ff850128-b008-4d17-9e32-465f87384bfb.png">

