### PR TITLE
FIO-7232 removed permissions button from FormGridBody

### DIFF
--- a/projects/angular-formio/grid/src/form/FormGridBody.component.html
+++ b/projects/angular-formio/grid/src/form/FormGridBody.component.html
@@ -13,7 +13,6 @@
             <button #create *ngIf="actionAllowed('formView')" class="btn btn-outline-secondary btn-sm form-btn form-btn-use" (click)="onRowAction($event, form, 'view')"><span class="fa fa-pencil bi bi-pencil"></span></button>&nbsp;
             <button #view *ngIf="actionAllowed('formSubmission')" class="btn btn-outline-secondary btn-sm form-btn" (click)="onRowAction($event, form, 'submission')"><span class="fa fa-list-alt bi bi-table"></span></button>&nbsp;
             <button #edit *ngIf="actionAllowed('formEdit')" class="btn btn-outline-secondary btn-sm form-btn" (click)="onRowAction($event, form, 'edit')"><span class="fa fa-edit bi bi-pencil-square"></span></button>&nbsp;
-            <button #permissions *ngIf="actionAllowed('formPermission')" class="btn btn-outline-secondary btn-sm form-btn" (click)="onRowAction($event, form, 'permissions')"><span class="fa fa-lock bi bi-database-lock"></span></button>&nbsp;
             <button #delete *ngIf="actionAllowed('formDelete')" class="btn btn-secondary btn-sm form-btn form-btn-delete" (click)="onRowAction($event, form, 'delete')" title="Delete form"><span class="fa fa-trash bi bi-trash"></span></button>
           </div>
         </div>


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7232

## Description

*The permission button was removed from FormGridBody, for a grid with gridType form, because there is no corresponding route for the permissions path. For the Formmanager application, the permissions button was added by changing the template for FormGridBody*

## Dependencies

*https://github.com/formio/formmanager/pull/172*