### PR TITLE
Fixing General access to Manager using formadmin formbuilder roles

### DIFF
--- a/projects/angular-formio/manager/src/form-manager.service.ts
+++ b/projects/angular-formio/manager/src/form-manager.service.ts
@@ -88,7 +88,7 @@ export class FormManagerService {
               this.access.userManagement = true;
             }
             else {
-              if (formadmin._id === roleId) {
+              if (formadmin && formadmin._id === roleId) {
                 this.access.formCreate = this.auth.formAccess.create_all.includes(roleId);
                 this.access.formEdit = this.auth.formAccess.update_all.includes(roleId);
                 this.access.formPermission = this.auth.formAccess.update_all.includes(roleId);
@@ -96,7 +96,7 @@ export class FormManagerService {
                 this.access.formView = this.auth.formAccess.read_all.includes(roleId);
                 this.access.formSubmission = this.auth.formAccess.read_all.includes(roleId);
               }
-              if (formbuilder._id === roleId) {
+              if (formbuilder && formbuilder._id === roleId) {
                 this.access.formCreate = this.auth.formAccess.create_all.includes(roleId);
                 this.access.formEdit = this.auth.formAccess.update_all.includes(roleId);
                 this.access.formPermission = this.auth.formAccess.update_all.includes(roleId);


### PR DESCRIPTION
Fixed general access to manager.

Form manager services was looking for formbuilder and formadmin roles that sometimes won't exist in the formio project causing a undefined reading _id. 

This error was blocking the feature to work correctly. 