### PR TITLE
Update formiojs version to 4.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^20.10.6",
     "bootstrap": "4",
     "codelyzer": "^6.0.2",
-    "formiojs": "^4.18.0",
+    "formiojs": "^4.19.0",
     "jasmine-core": "^5.0.0",
     "jasmine-spec-reporter": "^7.0.0",
     "karma": "^6.4.0",


### PR DESCRIPTION
In the latest stable version of `@formio/angular` 7.0.0 we have a hard dependency on `formiojs` styles here:

https://github.com/formio/angular/blob/v7.0.0/projects/angular-formio/src/components/formio/formio.component.ts#L11

It means that it doesn't matter which `formiojs` version I will use as a peer dependency in my project I will still get a styles from a version specified in your repository and they will be inlined in the `FormioComponent` during build time.

https://github.com/formio/formio.js/pull/5447

I have this issue in my project and the long-term fix could probably be a separate loading of styles and not inlining them but so far package update may also work fine (as the local style override...but override does not look like the best solution).



