### PR TITLE
FIO-8004 Fixed loader incorrectly showing in embed reports

### DIFF
--- a/projects/angular-formio/src/components/formioreport/formioreport.component.ts
+++ b/projects/angular-formio/src/components/formioreport/formioreport.component.ts
@@ -17,6 +17,8 @@ export class FormioReportComponent extends FormioComponent implements OnInit, On
   @Output() fetchDataError = new EventEmitter<any>();
   @ViewChild('report', { static: true }) declare formioElement?: ElementRef<any>;
 
+  public isLoading: boolean;
+
   setFormFromSrc() {
     this.service.loadSubmission({ params: { live: 1 } }).subscribe(
       (report: FormioReport) => {
@@ -24,6 +26,7 @@ export class FormioReportComponent extends FormioComponent implements OnInit, On
         if (report && report.data) {
           this.ngZone.runOutsideAngular(() => {
             this.setForm({ components: [], report });
+            this.isLoading = false;
           });
         }
       },
@@ -41,6 +44,7 @@ export class FormioReportComponent extends FormioComponent implements OnInit, On
     if (changes.report && changes.report.currentValue) {
       this.ngZone.runOutsideAngular(() => {
         this.setForm({ report: changes.report.currentValue, components: [] });
+        this.isLoading = false;
       });
     }
   }


### PR DESCRIPTION
https://formio.atlassian.net/browse/FIO-8004

Previously, every form that is loaded in formio/angular was using a setForm function, that handles loading functionality through a idLoading flag. Reports are loaded a bit differently than other forms, and isLoading flag never resets in that case, that's why the code to reset that flag was added explicitly to the functions that set up reports