### PR TITLE
FIO-8915: fixed an issue where errors list does not display in formmanager and formview pro

### DIFF
--- a/projects/angular-formio/src/FormioBaseComponent.ts
+++ b/projects/angular-formio/src/FormioBaseComponent.ts
@@ -445,7 +445,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
           }
           : {
             message: error.message || error.toString(),
-            paths: error.path ? [error.path] : [],
+            paths: (error.path || error.formattedKeyOrPath) ? [error.path || error.formattedKeyOrPath] : [],
           }
         : {
           message: '',
@@ -479,10 +479,6 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
             });
           }
         }
-
-        if (!this.noAlerts) {
-          this.formio.showErrors();
-        }
       }
 
       if (shouldErrorDisplay) {
@@ -493,6 +489,10 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
         });
       }
     });
+
+    if (this.formio && !this.noAlerts) {
+      this.formio.showErrors(errors);
+    }
   }
 
   focusOnComponet(key: any) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8915

## Description

**What changed?**

Before, in formiojs 4x branch, the showErrors method could accept a single error and add it to all form errors (this.errors). When the error is undefined, this method showed all other form errors any way. In formiojs 5.x this method expects the list of errors, if errors are empty, the method just removes the errors list. So, this PR changed the showErrors to call it with errors argument.

## How has this PR been tested?

Manually 

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
