### PR TITLE
FIO-8819: Removed duplicate request on form manager search

### DIFF
--- a/projects/angular-formio/manager/src/index/index.component.ts
+++ b/projects/angular-formio/manager/src/index/index.component.ts
@@ -66,7 +66,6 @@ export class FormManagerIndexComponent implements OnInit, AfterViewInit {
     localStorage.setItem('query', JSON.stringify(this.gridQuery));
     localStorage.setItem('searchInput', search);
     this.formGrid.pageChanged({page: 1, itemPerPage: this.gridQuery.limit});
-    this.formGrid.refreshGrid(this.gridQuery);
   }
 
   clearSearch() {
@@ -80,9 +79,8 @@ export class FormManagerIndexComponent implements OnInit, AfterViewInit {
     if (this.searchElement?.nativeElement) {
       this.searchElement.nativeElement.value = '';
     }
+    this.formGrid.query = this.gridQuery;
     this.formGrid.pageChanged({page: 1});
-    this.formGrid.query = {};
-    this.formGrid.refreshGrid(this.gridQuery);
   }
 
   onAction(action: any) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8819

## Description

**Issue**: The formManager search calls `this.formGrid.pageChanged`, which internally calls the `refreshGrid` method. The `refreshGrid` method makes an HTTP request to get forms. Additionally, the formManager search also calls `this.formGrid.refreshGrid`. This results in two `refreshGrid` calls and two HTTP requests with the same data. Furthermore, the variables `this.gridQuery` and `this.formGrid.query` are equal because `this.gridQuery` is passed as a prop to `this.formGrid`.

Regarding the clearSearch method: when we manually reassign `this.gridQuery` to another object, `this.gridQuery` and `this.formGrid.query` are no longer equal, so we need to reassign `this.formGrid.query` before making the API call.

**Solution**: Remove the second `refreshGrid` call.

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
