### PR TITLE
FIO-8993: Fixed component validation message

### DIFF
--- a/projects/angular-formio/src/FormioBaseComponent.ts
+++ b/projects/angular-formio/src/FormioBaseComponent.ts
@@ -463,7 +463,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
             components.forEach((comp) => comp.setCustomValidity(messageText, true));
             this.alerts.addAlert({
               type: 'danger',
-              message: message[index],
+              message: Array.isArray(message) ? message[index] : message,
               component,
             });
             shouldErrorDisplay = false;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8993

## Description

**Issue**: The `message` variable can be either a single string or an array of strings. When `message` is a single string, using `message[0]` incorrectly accesses the first character of the string instead of the intended first element of an array.

**Solution**: Add a check to determine if `message` is an array or a single string before accessing its elements.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
