### PR TITLE
FIO-9006: Fixed cached grid responses

### DIFF
--- a/projects/angular-formio/grid/src/form/FormGridBody.component.ts
+++ b/projects/angular-formio/grid/src/form/FormGridBody.component.ts
@@ -17,7 +17,10 @@ export class FormGridBodyComponent extends GridBodyComponent implements OnDestro
 
   load(formio: FormioPromiseService, query?: any) {
     query = query || {};
-    return formio.loadForms({ params: query })
+    return formio.loadForms(
+      { params: query },
+      { headers: { 'cache-control': 'no-cache' } },
+      )
       .then((forms: any) => this.setRows(query, forms))
       .then(() => this.attachTooltips());
   }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9006

## Description

**Issue**: When the grid requests forms from the API server, the server generates an `ETag` header for the response. The browser uses this `ETag` with the `If-None-Match` header in subsequent requests so the server can validate if the content has changed. If not, it returns a `304 Not Modified` status, indicating to the browser to use the cached version of the response.

**Example**: When the grid already has 1 page with the total items equal to the maximum items per page to show, and the user tries to add a new form that should be displayed on the second page of grid items, the following issue occurs:

1. The user navigates back to the grid.
2. The grid sends a request to get the list of items with the `If-None-Match` header.
3. The server prepares a response with the same body but a different `Content-Range` header because a new form was added.
4. [Based on the implementation](https://github.com/expressjs/express/blob/4.21.0/lib/utils.js#L270-L278) in the Express library, the `ETag` only considers the body of the response and not the headers.
5. As a result, Express generates the same `ETag`, which matches the `If-None-Match` request header.
6. Consequently, Express sends a `304 Not Modified` status, and the browser uses the cached version of the response with the old `Content-Range` header.
7. Grid pagination depends on the `Content-Range` header to display pagination correctly. In this case, the user does not see the new available page in the pagination.

**Solution**: Based on the [fresh function](https://github.com/jshttp/fresh/blob/v0.5.2/index.js#L47-L49), we can use the `Cache-Control` request header with the `no-cache` value to force the Express server not to return a `304 Not Modified` status. This ensures the server sends the updated response with the correct `Content-Range` header, allowing the grid to display the correct pagination.

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
