### PR TITLE
FIO-9258: separated webform options from angular webform options, fix some eslint errors, fix form options type

### DIFF
--- a/projects/angular-formio/embed/src/builder.component.ts
+++ b/projects/angular-formio/embed/src/builder.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, ViewChild, Output, EventEmitter, AfterViewInit } from '@angular/core';
-import { FormBuilder } from '@formio/js';
+import {Form, FormBuilder, Webform} from '@formio/js';
 import WebformBuilder from '@formio/js/lib/cjs/WebformBuilder';
 
 @Component({
@@ -8,8 +8,8 @@ import WebformBuilder from '@formio/js/lib/cjs/WebformBuilder';
 })
 export class FormioBuilder implements AfterViewInit {
     @ViewChild('formio') element: ElementRef;
-    @Input() form?: Object | null;
-    @Input() options?: Object = {};
+    @Input() form?: Form['options'] | null;
+    @Input() options?: FormBuilder['options'] = {};
     @Output() change = new EventEmitter<any>();
     @Output() ready = new EventEmitter<any>();
     @Output() error = new EventEmitter<any>();

--- a/projects/angular-formio/embed/src/formio.component.ts
+++ b/projects/angular-formio/embed/src/formio.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild, ElementRef, Input, Output, EventEmitter, OnChanges, AfterViewInit } from '@angular/core';
-import { FormioCore as Formio, Webform } from '@formio/js';
-import { Form, Submission } from '@formio/core/types';
+import { FormioCore as Formio, Webform, Form } from '@formio/js';
+import { Form as formType, Submission } from '@formio/core/types';
 
 @Component({
     selector: 'formio',
@@ -8,10 +8,10 @@ import { Form, Submission } from '@formio/core/types';
 })
 export class FormioComponent implements AfterViewInit {
     @Input() src?: string;
-    @Input() form?: Form | null;
+    @Input() form?: formType | null;
     @Input() submission?: Submission | null;
     @Input() url?: string;
-    @Input() options?: Webform['options'] = {};
+    @Input() options?: Form['options'] = {};
     @Output() ready = new EventEmitter<Webform>();
     @Output() submit = new EventEmitter<object>();
     @Output() error = new EventEmitter<any>();

--- a/projects/angular-formio/embed/src/formio.component.ts
+++ b/projects/angular-formio/embed/src/formio.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild, ElementRef, Input, Output, EventEmitter, OnChanges, AfterViewInit } from '@angular/core';
 import { FormioCore as Formio, Webform } from '@formio/js';
-import { Form, Submission } from '@formio/core/types'
+import { Form, Submission } from '@formio/core/types';
 
 @Component({
     selector: 'formio',
@@ -11,7 +11,7 @@ export class FormioComponent implements AfterViewInit {
     @Input() form?: Form | null;
     @Input() submission?: Submission | null;
     @Input() url?: string;
-    @Input() options?: Webform["options"] = {};
+    @Input() options?: Webform['options'] = {};
     @Output() ready = new EventEmitter<Webform>();
     @Output() submit = new EventEmitter<object>();
     @Output() error = new EventEmitter<any>();

--- a/projects/angular-formio/src/FormioBaseComponent.ts
+++ b/projects/angular-formio/src/FormioBaseComponent.ts
@@ -5,7 +5,7 @@ import { FormioAppConfig } from './formio.config';
 import {AngularFormioOptions, FormioError, FormioForm, FormioRefreshValue} from './formio.common';
 import { assign, get, isEmpty } from 'lodash';
 import { CustomTagsService } from './custom-tags.service';
-import {Utils, Webform} from '@formio/js';
+import {Form, Utils, Webform} from '@formio/js';
 import { AlertsPosition } from './types/alerts-position';
 const { Evaluator, fastCloneDeep } = Utils;
 
@@ -18,7 +18,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
   @Input() src?: string;
   @Input() url?: string;
   @Input() service?: FormioService;
-  @Input() options?: Webform['options'] & AngularFormioOptions;
+  @Input() options?: Form['options'] & AngularFormioOptions;
   @Input() noeval ? = Evaluator.noeval;
   @Input() formioOptions?: any;
   @Input() renderOptions?: any;
@@ -213,7 +213,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     const extraTags = this.customTags ? this.customTags.tags : [];
-    const defaultOptions: Webform['options'] & AngularFormioOptions = {
+    const defaultOptions: Form['options'] & AngularFormioOptions = {
       errors: {
         message: 'Please fix the following errors before submitting.'
       },

--- a/projects/angular-formio/src/FormioBaseComponent.ts
+++ b/projects/angular-formio/src/FormioBaseComponent.ts
@@ -2,10 +2,10 @@ import { Component, ElementRef, EventEmitter, Input, NgZone, OnChanges, OnDestro
 import { FormioService } from './formio.service';
 import { FormioAlerts } from './components/alerts/formio.alerts';
 import { FormioAppConfig } from './formio.config';
-import { FormioError, FormioForm, FormioOptions, FormioRefreshValue } from './formio.common';
+import {AngularFormioOptions, FormioError, FormioForm, FormioRefreshValue} from './formio.common';
 import { assign, get, isEmpty } from 'lodash';
 import { CustomTagsService } from './custom-tags.service';
-import { Utils } from '@formio/js';
+import {Utils, Webform} from '@formio/js';
 import { AlertsPosition } from './types/alerts-position';
 const { Evaluator, fastCloneDeep } = Utils;
 
@@ -18,7 +18,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
   @Input() src?: string;
   @Input() url?: string;
   @Input() service?: FormioService;
-  @Input() options?: FormioOptions;
+  @Input() options?: Webform['options'] & AngularFormioOptions;
   @Input() noeval ? = Evaluator.noeval;
   @Input() formioOptions?: any;
   @Input() renderOptions?: any;
@@ -34,7 +34,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
   @Input() hooks?: any = {};
   @Input() renderer?: any;
   @Input() watchSubmissionErrors ? = false;
-  @Input() dataTableActions? : any = []
+  @Input() dataTableActions?: any = [];
   @Output() render = new EventEmitter<object>();
   @Output() customEvent = new EventEmitter<object>();
   @Output() fileUploadingStatus = new EventEmitter<string>();
@@ -213,7 +213,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     const extraTags = this.customTags ? this.customTags.tags : [];
-    const defaultOptions: FormioOptions = {
+    const defaultOptions: Webform['options'] & AngularFormioOptions = {
       errors: {
         message: 'Please fix the following errors before submitting.'
       },

--- a/projects/angular-formio/src/components/formbuilder/formbuilder.component.ts
+++ b/projects/angular-formio/src/components/formbuilder/formbuilder.component.ts
@@ -38,7 +38,7 @@ export class FormBuilderComponent implements OnInit, OnChanges, OnDestroy {
   public componentAdding = false;
   private refreshSubscription: Subscription;
   @Input() form?: FormioForm;
-  @Input() options?: object & AngularFormioOptions;
+  @Input() options?: FormBuilder['options'] & AngularFormioOptions;
   @Input() formbuilder?: any;
   @Input() noeval ? = false;
   @Input() refresh?: Observable<void>;

--- a/projects/angular-formio/src/components/formbuilder/formbuilder.component.ts
+++ b/projects/angular-formio/src/components/formbuilder/formbuilder.component.ts
@@ -14,8 +14,8 @@ import {
 } from '@angular/core';
 import { FormioAppConfig } from '../../formio.config';
 import {
+  AngularFormioOptions,
   FormioForm,
-  FormioOptions
 } from '../../formio.common';
 import { Formio, FormBuilder, Utils } from '@formio/js';
 import { assign } from 'lodash';
@@ -38,7 +38,7 @@ export class FormBuilderComponent implements OnInit, OnChanges, OnDestroy {
   public componentAdding = false;
   private refreshSubscription: Subscription;
   @Input() form?: FormioForm;
-  @Input() options?: FormioOptions;
+  @Input() options?: object & AngularFormioOptions;
   @Input() formbuilder?: any;
   @Input() noeval ? = false;
   @Input() refresh?: Observable<void>;

--- a/projects/angular-formio/src/formio.common.ts
+++ b/projects/angular-formio/src/formio.common.ts
@@ -18,12 +18,12 @@ export interface AccessSetting {
 }
 
 export interface FormioReport {
-  form: string,
-  roles: object,
-  access: object,
-  metadata: object,
-  data: object,
-  project: string,
+  form: string;
+  roles: object;
+  access: object;
+  metadata: object;
+  data: object;
+  project: string;
 }
 
 export interface FormioForm {
@@ -38,7 +38,7 @@ export interface FormioForm {
   tags?: string[];
   access?: AccessSetting[];
   submissionAccess?: AccessSetting[];
-  report?: FormioReport
+  report?: FormioReport;
 }
 
 export interface ComponentInstance {
@@ -78,13 +78,9 @@ export interface FormioHookOptions {
   beforeSubmit: FormioBeforeSubmit;
 }
 
-export interface FormioOptions {
+export interface AngularFormioOptions {
   errors?: ErrorsOptions;
   alerts?: AlertsOptions;
   alertsPosition?: AlertsPosition;
   disableAlerts?: boolean;
-  i18n?: object;
-  fileService?: object;
-  hooks?: FormioHookOptions;
-  sanitizeConfig?: any;
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9258

## Description

**What changed?**

Gave the angular formio component options the webform options type along with extending the specific angular webform options as well. Also fixed some eslint errors

**Why have you chosen this solution?**

Give correct type definitions to formio

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Manually tested

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
