### PR TITLE
DESTROY THE BUILDER

### DIFF
--- a/projects/angular-formio/embed/src/builder.component.ts
+++ b/projects/angular-formio/embed/src/builder.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, ViewChild, Output, EventEmitter, AfterViewInit } from '@angular/core';
+import {Component, ElementRef, Input, ViewChild, Output, EventEmitter, AfterViewInit, OnDestroy} from '@angular/core';
 import {Form, FormBuilder, Webform} from '@formio/js';
 import WebformBuilder from '@formio/js/lib/cjs/WebformBuilder';
 
@@ -7,7 +7,7 @@ import WebformBuilder from '@formio/js/lib/cjs/WebformBuilder';
     template: '<div #formio></div>',
     standalone: false
 })
-export class FormioBuilder implements AfterViewInit {
+export class FormioBuilder implements AfterViewInit, OnDestroy {
     @ViewChild('formio') element: ElementRef;
     @Input() form?: Form['options'] | null;
     @Input() options?: FormBuilder['options'] = {};
@@ -66,4 +66,8 @@ export class FormioBuilder implements AfterViewInit {
             this.ready.emit(this.instance);
         }).catch((err) => this.error.emit(err));
     }
+
+  ngOnDestroy(): void {
+      this.instance.destroy(true);
+  }
 }


### PR DESCRIPTION
## Description

**What changed?**

When the formio-builder component is destroyed, call destroy on the builder instance to clean up memory

**Why have you chosen this solution?**

Let say you have some kind of app that navigates between forms and displays a builder to edit that form. When the app navigates to another form the angular formio-builder is destroyed but the webform from the builder is still referenced in Formio.forms. We need to make sure to call destroy on that builder instance so that a memory leak does not occure

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

Manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
